### PR TITLE
feat: expose contracts data port

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   contracts:
     platform: linux/amd64
@@ -8,7 +8,8 @@ services:
       PORT: 8547
     command: ./scripts/start_e2e.sh
     ports:
-      - '8545:8544'
+      - "8545:8544"
+      - "8547:8547"
 
   falafel:
     platform: linux/amd64
@@ -18,13 +19,13 @@ services:
       CONTRACTS_HOST: http://contracts:8547
       NUM_INNER_ROLLUP_TXS: ${NUM_INNER_ROLLUP_TXS:-3}
       NUM_OUTER_ROLLUP_PROOFS: ${NUM_OUTER_ROLLUP_PROOFS:-1}
-      PROVERLESS: 'true'
+      PROVERLESS: "true"
       MAX_CIRCUIT_SIZE: 8192
       PROOF_GENERATOR_MODE: local
-      NO_BUILD: 'true'
+      NO_BUILD: "true"
       PORT: 8081
     depends_on:
       - contracts
     command: start:e2e
     ports:
-      - '8081:8081'
+      - "8081:8081"

--- a/docker-compose.fork.yml
+++ b/docker-compose.fork.yml
@@ -14,6 +14,8 @@ services:
       PORT: 8547
       network: "DONT_CARE"
     command: ./scripts/start_e2e.sh
+    ports:
+      - "8547:8547"
     depends_on:
       - fork
 


### PR DESCRIPTION
Update the docker compose files to expose port 8547. This will allow users to view the deployed contract addresses by pinging:
```
curl http://localhost:8547
```
While running the compose files