### PR TITLE
fix broken links

### DIFF
--- a/hackathons/README.md
+++ b/hackathons/README.md
@@ -21,7 +21,7 @@ Also be sure to check out [this list of resources](../README.md)
 
 ### Getting started on Noir
 
-See the [Getting Started](https://noir-lang.org/docs/getting_started/installation/) section of the Noir docs to get set up with Noir.
+See the [Getting Started](https://noir-lang.org/docs/getting_started/noir_installation) section of the Noir docs to get set up with Noir.
 
 ### Getting started on Aztec
 

--- a/workshops/devconnect-2023/build-account-contract/README.md
+++ b/workshops/devconnect-2023/build-account-contract/README.md
@@ -91,5 +91,5 @@ This function is required by the protocol to know how to handle private notes.
 ## Future work
 
 - Implement signature verification
-- Discuss [Authentication witnesses](https://docs.aztec.network/learn/concepts/accounts/authwit)
+- Discuss [Authentication witnesses](https://docs.aztec.network/aztec/concepts/accounts/authwit)
 - Review the existing Schnorr signer [implementation](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-contracts/src/contracts/schnorr_account_contract)


### PR DESCRIPTION
changed made

https://noir-lang.org/docs/getting_started/installation/ - https://noir-lang.org/docs/getting_started/noir_installation

https://docs.aztec.network/learn/concepts/accounts/authwit - https://docs.aztec.network/aztec/concepts/accounts/authwit

The previous links were non-functional, so I have replaced them with new, operational ones.

