### PR TITLE
fix: Fix missing closing angle bracket Update README.md

### DIFF
--- a/workshops/devconnect-2023/nethermind-and-progcrypto/README.md
+++ b/workshops/devconnect-2023/nethermind-and-progcrypto/README.md
@@ -154,4 +154,4 @@ Try to do it twice
 
 ### Get vote
 
-`aztec-cli call get_vote --args 1 -c ./target/Voting.json -ca <contract-address`
+`aztec-cli call get_vote --args 1 -c ./target/Voting.json -ca <contract-address>`


### PR DESCRIPTION
### Description
I noticed a typo in the `aztec-cli` command for fetching a vote. The command was missing a closing angle bracket `>` at the end. This has been corrected to ensure the command works as expected.  

Before:  
```bash  
aztec-cli call get_vote --args 1 -c ./target/Voting.json -ca <contract-address  
```  

After:  
```bash  
aztec-cli call get_vote --args 1 -c ./target/Voting.json -ca <contract-address>  
```  
