### PR TITLE
fix: Fix broken link to schnorr_account_contract Update README.md

### DIFF
--- a/workshops/devconnect-2023/build-account-contract/README.md
+++ b/workshops/devconnect-2023/build-account-contract/README.md
@@ -92,4 +92,4 @@ This function is required by the protocol to know how to handle private notes.
 
 - Implement signature verification
 - Discuss [Authentication witnesses](https://docs.aztec.network/aztec/concepts/accounts/authwit)
-- Review the existing Schnorr signer [implementation](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-contracts/src/contracts/schnorr_account_contract)
+- Review the existing Schnorr signer [implementation](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-contracts/contracts/schnorr_account_contract)


### PR DESCRIPTION
I noticed that the link to `schnorr_account_contract` was broken, so I updated it to the correct one.