### PR TITLE
docs: fix article usage and phrasing in documentation

### DIFF
--- a/hackathons/TOOLS.md
+++ b/hackathons/TOOLS.md
@@ -45,7 +45,7 @@
 ##### Cryptography
 
 - [Sparse Merkle Tree Verifier](https://github.com/vocdoni/smtverifier-noir/tree/main) - a library for verification of sparse Merkle trees
-- [RSA](https://github.com/SetProtocol/noir-rsa) - this repository contains an implementation of a RSA signature verify for the Noir language
+- [RSA](https://github.com/SetProtocol/noir-rsa) - this repository contains an implementation of an RSA signature verify for the Noir language
 - [Merkle Root](https://github.com/tomoima525/noir-merkle-root) - a library for calculating Merkle root from given inputs. Using the Poseidon function for hashing
 - [Quantized arithmetic](https://github.com/storswiftlabs/quantized_arithmetic) - a library for quantized value operations of zero-point quantization
 - [SHA-1](https://github.com/michaelelliot/noir-sha1) - a library for generating hashes using SHA-1 hashing function
@@ -60,7 +60,7 @@
 
 - [SKProof](https://github.com/0x3327/skproof) - a Scikit-learn compatible Python library for generating ZK proofs of execution
 - [ML](https://github.com/metavind/noir-ml) - a library for implementing neural networks in Noir
-- [zkML-Noir](https://github.com/storswiftlabs/zkml-noir) - a library for Python ML model transcoding Noir, including various algorithms such as Decision tree, K-Means, XGBoost, FNN, CNN
+- [zkML-Noir](https://github.com/storswiftlabs/zkml-noir) - a library for Python ML model transcoding to Noir, including various algorithms such as Decision tree, K-Means, XGBoost, FNN, CNN
 - [Matrix Operations](https://github.com/storswiftlabs/matrix_operations) - a library for matrix operations that provides functionality for performing various matrix operations
 - [Convolution](https://github.com/storswiftlabs/convolution) - a library for Convolutional Neural Network (CNN) library in Noir, including Convolutional layers, Pooling layers, and Linear (fully connected) layers.
 


### PR DESCRIPTION
Spotted a couple of small issues while reading through the docs:  
- Changed *a RSA* to *an RSA* since "R" is pronounced with a vowel sound.  
- Clarified *transcoding Noir* to *transcoding to Noir*, which I believe was the intended meaning.
