### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/noir-starter-traffic.yml
+++ b/.github/workflows/noir-starter-traffic.yml
@@ -13,7 +13,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     # Calculates traffic and clones and stores in CSV file
     - name: GitHub traffic 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get version
         id: versions_step


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected