### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/sparta.yml
+++ b/.github/workflows/sparta.yml
@@ -40,4 +40,4 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0