### PR TITLE
docs: fix two dead links to the contract tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We keep all our external content and resources here, as well as tracking what we
 
 ⌛ [Sandbox Getting Started](https://docs.aztec.network/guides/getting_started)
 
-📑 Learn by doing with [Aztec Tutorials](https://docs.aztec.network/developers/tutorials/codealong/contract_tutorials/private_voting_contract)
+📑 Learn by doing with [Aztec Tutorials](https://docs.aztec.network/developers/docs/tutorials/contract_tutorials/private_voting_contract)
 
 🔷 [Aztec: The Hybrid zkRollup](https://medium.com/aztec-protocol/aztec-the-hybrid-zkrollup-a90a197bf22e)
 

--- a/hackathons/INSPIRATION.md
+++ b/hackathons/INSPIRATION.md
@@ -65,7 +65,7 @@ You could try to implement these in vanilla Noir, or as Aztec contracts.
 
 - **zkPatreon** - privately unlock token-gated content by using Ethereum Storage Proofs in Noir
 - **zkEmail** - privately prove that some email was received, while hiding any private data in the e-mail, without trusting a centralized server to keep your privacy. You can use [this library](https://github.com/zkemail/zkemail.nr).
-- **Privacy Preserving Rewards Protocol** - an app or protocol that rewards participants for doing a specific on-chain action without revealing how much. This [tutorial](https://docs.aztec.network/developers/tutorials/codealong/contract_tutorials/crowdfunding_contract) may be helpful.
+- **Privacy Preserving Rewards Protocol** - an app or protocol that rewards participants for doing a specific on-chain action without revealing how much. This [tutorial](https://docs.aztec.network/developers/docs/tutorials/contract_tutorials/crowdfunding_contract) may be helpful.
 
 ## Gaming 👾
 


### PR DESCRIPTION
## Problem

Both links into the contract tutorials use the old `/developers/tutorials/codealong/` path, which now 404s:

| File | Link |
|---|---|
| `README.md:26` | `.../developers/tutorials/codealong/contract_tutorials/private_voting_contract` |
| `hackathons/INSPIRATION.md:68` | `.../developers/tutorials/codealong/contract_tutorials/crowdfunding_contract` |

The README one is the more painful of the two: it is the "📑 Learn by doing with Aztec Tutorials" line near the top, so it is among the first things a newcomer clicks.

## Fix

Drop the `codealong/` segment and use the current `/developers/docs/tutorials/contract_tutorials/` prefix.

## Verification

Both old URLs confirmed 404 twice; both replacements confirmed 200 twice.

Related: #561 asks for an automated URL checker, which would have caught these.

Note on overlap: #541 also edits `hackathons/INSPIRATION.md`, but it changes lines 14, 77 and 91 (wording/casing) and does not touch line 68, so the two should not conflict.